### PR TITLE
Android Studio C 対応/各種 SdkVersion インクリメント/OSS アップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # HackerNewsChecker とは
 
-Wada Akira が Android エンジニアとして、スキルを向上させるために作成した学習用の Android アプリ。
-また、Wada Akira のスキルチェックとして利用されることも想定している。
+Wada Akira が Android エンジニアとして、スキルを向上させるために作成した学習用の Android アプリ。 また、Wada Akira
+のスキルチェックとして利用されることも想定している。
 
 ## アプリの動作要件
 
-- Android 9.0 以上の実機/エミュレータでなければ動作しない
+- Android 10 以上の実機/エミュレータでなければ動作しない
 - デュアルディスプレイ等、複数のディスプレイを持つデバイスへのインストールは想定していない
 - Pad、Android TV、ウェアラブル等、スマートフォーン以外のデバイスへのインストールは想定していない
 
@@ -78,14 +78,14 @@ Wada Akira が Android エンジニアとして、スキルを向上させるた
 
 ## 開発環境
 
-- Mac Big Sur 11.6
-- Android Studio Arctic Fox 2020.3.1 Patch 2 + kotlin 1.5.31
+- Mac Montrey 12.4(intel core i5)
+- Android Studio Chipmunk | 2021.2.1 Patch 1
+- kotlin 1.7.0
 
 ## アプリのライセンス
 
-MIT ライセンスを採用している。
-Wada Akira の名称を明記してもらえれば利用は自由だが、当アプリに関わるあらゆる不具合について、Wada Akira は一切の責任を負わない。
-また、Android OS のバージョンアップ、Android OS の退廃、OSS の非推奨化等、当アプリのメンテナンスが必要な場合も、
-Wada Akira はメンテナンスについて一切の責任を負わない。
+MIT ライセンスを採用している。 Wada Akira の名称を明記してもらえれば利用は自由だが、当アプリに関わるあらゆる不具合について、Wada Akira は一切の責任を負わない。
+また、Android OS のバージョンアップ、Android OS の退廃、OSS の非推奨化等、当アプリのメンテナンスが必要な場合も、 Wada Akira
+はメンテナンスについて一切の責任を負わない。
 
 最後に、当アプリは、作成者の目的を達成するか、作成者が不要と判断した時、事前連絡なしに公開を終了させることがある。

--- a/RELEASENOTE.md
+++ b/RELEASENOTE.md
@@ -1,26 +1,46 @@
+# ver1.8（2022/6/26 リリース）
+
+- targetSdkVersion/compileSdkVersion を 32 に変更
+- Gradle のバージョンアップ
+- OSS をアップデート
+- minSdkVersion を 29 に変更
+
+# ver1.7（リリース）
+
+- Java11 に対応
+- Android Gradle Plugin をバージョンアップ
+- テスト環境をバージョンアップ
+
 # ver1.6（2021/9/25 リリース）
+
 - hilt を導入
 - main/history をモジュール分割
 - パッケージを修正
 
 # ver1.5（2021/9/24 リリース）
+
 - targetSdkVersion/compileSdkVersion を 31 に変更
 - Gradle のバージョンアップ
 - OSS をアップデート
 - minSdkVersion を 28 に変更
 
 # ver1.4（2021/3/13 リリース）
+
 - CoroutineDispatcher を DI するよう修正
 
 # ver1.3（2021/3/8 リリース）
+
 - 記事情報を１けんずつ取得するよう修正
 
 # ver1.2（2021/3/3 リリース）
+
 - targetSdkVersion/compileSdkVersion を 30 に変更
 - 一部 OSS をアップデート
 
 # ver1.1（2020/11/22 リリース）
+
 - Hacker News Checker をモジュール分割
 
 # ver1.0（2020/11/15 リリース）
+
 - Hacker News Checker を公開

--- a/android_common.gradle
+++ b/android_common.gradle
@@ -1,9 +1,9 @@
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
-        minSdkVersion 28
-        targetSdkVersion 31
+        minSdkVersion 29
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ apply from: rootProject.file("android_common.gradle")
 android {
     defaultConfig {
         applicationId "com.example.hackernewschecker"
-        versionName "1.7"
+        versionName "1.8"
         versionCode generateVersionCode(versionName)
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
+        classpath "com.android.tools.build:gradle:7.2.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ buildscript {
     ext.moshi_version = "1.13.0"
     ext.room_version = "2.4.2"
     ext.oss_licenses_version = "17.0.0"
-    ext.spek_version = "2.0.17"
-    ext.coroutines_test_version = "1.4.1"
-    ext.mockk_version = "1.12.1"
+    ext.spek_version = "2.0.18"
+    ext.coroutines_test_version = "1.6.3"
+    ext.mockk_version = "1.12.4"
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.swipe_refresh_layout_version = "1.1.0"
     ext.hilt_version = '2.42'
     ext.coroutine_version = '1.6.3'
-    ext.okhttp_version = '4.9.0'
+    ext.okhttp_version = '4.10.0'
     ext.retrofit_ver = "2.9.0"
     ext.moshi_version = "1.11.0"
     ext.room_version = "2.3.0"

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext.kotlin_version = "1.7.0"
     ext.core_ktx_version = "1.8.0"
     ext.app_compat_version = "1.4.2"
-    ext.material_version = "1.4.0"
-    ext.constraint_layout_version = "2.1.0"
+    ext.material_version = "1.6.1"
+    ext.constraint_layout_version = "2.1.4"
     ext.swipe_refresh_layout_version = "1.1.0"
     ext.hilt_version = '2.42'
     ext.coroutine_version = '1.3.9'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.coroutine_version = '1.6.3'
     ext.okhttp_version = '4.10.0'
     ext.retrofit_ver = "2.9.0"
-    ext.moshi_version = "1.11.0"
+    ext.moshi_version = "1.13.0"
     ext.room_version = "2.3.0"
     ext.oss_licenses_version = "17.0.0"
     ext.spek_version = "2.0.17"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.okhttp_version = '4.10.0'
     ext.retrofit_ver = "2.9.0"
     ext.moshi_version = "1.13.0"
-    ext.room_version = "2.3.0"
+    ext.room_version = "2.4.2"
     ext.oss_licenses_version = "17.0.0"
     ext.spek_version = "2.0.17"
     ext.coroutines_test_version = "1.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.constraint_layout_version = "2.1.4"
     ext.swipe_refresh_layout_version = "1.1.0"
     ext.hilt_version = '2.42'
-    ext.coroutine_version = '1.3.9'
+    ext.coroutine_version = '1.6.3'
     ext.okhttp_version = '4.9.0'
     ext.retrofit_ver = "2.9.0"
     ext.moshi_version = "1.11.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     // OSS のバージョンを定義
-    ext.kotlin_version = "1.5.31"
-    ext.core_ktx_version = "1.6.0"
-    ext.app_compat_version = "1.3.1"
+    ext.kotlin_version = "1.7.0"
+    ext.core_ktx_version = "1.8.0"
+    ext.app_compat_version = "1.4.2"
     ext.material_version = "1.4.0"
     ext.constraint_layout_version = "2.1.0"
     ext.swipe_refresh_layout_version = "1.1.0"
-    ext.hilt_version = '2.38.1'
+    ext.hilt_version = '2.42'
     ext.coroutine_version = '1.3.9'
     ext.okhttp_version = '4.9.0'
     ext.retrofit_ver = "2.9.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip


### PR DESCRIPTION
- targetSdkVersion/compileSdkVersion を 32 に変更
- Gradle のバージョンアップ
- OSS をアップデート
- minSdkVersion を 29 に変更